### PR TITLE
[PEE-20] Add dummy protected routes

### DIFF
--- a/peerloop/core/dependencies/auth.py
+++ b/peerloop/core/dependencies/auth.py
@@ -1,0 +1,28 @@
+from typing import Annotated
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import Depends
+from fastapi.security import OAuth2PasswordBearer
+
+from peerloop.domain.user.exceptions import UserNotVerifiedError
+from peerloop.domain.user.models import User
+from peerloop.domain.user.service import UserService
+
+oauth_bearer = OAuth2PasswordBearer(tokenUrl="/api/v1/login", scheme_name="JWT")
+
+
+@inject
+async def get_current_user(
+    token: Annotated[str, Depends(oauth_bearer)],
+    user_service: UserService = Depends(Provide["user_container.user_service"]),
+) -> User:
+    user_id = user_service.token_manager.decode_token(token=token)
+    user = await user_service.get_user_by_id(user_id=int(user_id))
+    return user
+
+
+@inject
+async def get_current_verified_user(verified_user: Annotated[User, Depends(get_current_user)]) -> User:
+    if not verified_user.is_verified:
+        raise UserNotVerifiedError("User Not Verified Error: email verification is required.")
+    return verified_user

--- a/peerloop/domain/auth/views.py
+++ b/peerloop/domain/auth/views.py
@@ -7,7 +7,7 @@ from peerloop.domain.auth.service import AuthService
 router = APIRouter(tags=["auth"])
 
 
-@router.post("/refresh_token", status_code=status.HTTP_200_OK, response_model=RefreshTokenResponse)
+@router.post("/refresh-token", status_code=status.HTTP_200_OK, response_model=RefreshTokenResponse)
 @inject
 async def refresh_token(
     request: RefreshTokenRequest, auth_service: AuthService = Depends(Provide["auth_container.auth_service"])

--- a/peerloop/domain/user/dtos.py
+++ b/peerloop/domain/user/dtos.py
@@ -56,3 +56,9 @@ class VerifyEmailRequest(BaseModel):
         if not is_valid_email_format(v):
             raise InvalidEmailError(f"Invalid Email Error: {v} is not a valid email address.")
         return v
+
+
+class UserResponse(BaseModel):
+    id: int = Field(default=...)
+    email: str = Field(default=...)
+    is_verified: bool = Field(default=...)

--- a/peerloop/domain/user/exceptions.py
+++ b/peerloop/domain/user/exceptions.py
@@ -31,6 +31,13 @@ class UserAlreadyExistsError(BaseCustomException):
         super().__init__(self.status_code, detail)
 
 
+class UserNotVerifiedError(BaseCustomException):
+    status_code = status.HTTP_400_BAD_REQUEST
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(self.status_code, detail)
+
+
 class IncorrectPasswordError(BaseCustomException):
     status_code = status.HTTP_400_BAD_REQUEST
     detail = "Incorrect password"

--- a/peerloop/domain/user/service.py
+++ b/peerloop/domain/user/service.py
@@ -17,6 +17,7 @@ from peerloop.domain.user.exceptions import (
     VerificationCodeDoesNotExistError,
     VerificationCodeExpiredError,
 )
+from peerloop.domain.user.models import User
 from peerloop.domain.user.repository import EmailVerificationRepository, UserRepository
 
 
@@ -100,3 +101,11 @@ class UserService:
 
         # Update is_verified to True
         await self.user_repo.update_by_id(id=user.id, params={"is_verified": True})
+
+    async def get_user_by_id(self, user_id: int) -> User:
+        # Check whether the user exists
+        user = await self.user_repo.get_by_id(id=user_id)
+        if user is None:
+            raise UserDoesNotExistError(f"User Does Not Exist Error: {user_id} does not exist.")
+
+        return user

--- a/peerloop/domain/user/views.py
+++ b/peerloop/domain/user/views.py
@@ -4,14 +4,17 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, status
 from fastapi.security import OAuth2PasswordRequestForm
 
+from peerloop.core.dependencies.auth import get_current_user, get_current_verified_user
 from peerloop.core.exceptions.validation import InvalidEmailError
 from peerloop.core.utils.validation import is_valid_email_format
 from peerloop.domain.user.dtos import (
     LoginResponse,
     RegisterRequest,
     RegisterResponse,
+    UserResponse,
     VerifyEmailRequest,
 )
+from peerloop.domain.user.models import User
 from peerloop.domain.user.service import UserService
 
 router = APIRouter(tags=["user"])
@@ -49,3 +52,15 @@ async def verify_email(
     request: VerifyEmailRequest, user_service: UserService = Depends(Provide["user_container.user_service"])
 ) -> None:
     await user_service.verify_email(email=request.email, verification_code=request.verification_code)
+
+
+@router.get("/me", status_code=status.HTTP_200_OK, response_model=UserResponse)
+@inject
+async def get_me(user: Annotated[User, Depends(get_current_user)]) -> User:
+    return user
+
+
+@router.get("/verified-me", status_code=status.HTTP_200_OK, response_model=UserResponse)
+@inject
+async def get_verified_me(user: Annotated[User, Depends(get_current_verified_user)]) -> User:
+    return user


### PR DESCRIPTION
## 💫 Motivation

- protected routes for logged in user and email-verified user are required

<br>

## 📌 Key Changes

- add `get_user_by_id()` to `UserService`
- add two global dependencies for protected routes
    - `get_current_user`: get current user and return it
    - `get_current_verified_user`: get current user, return it if the user is verified and raise `UserNotVerifiedError` if the user is not verified
- create two dummy protected endpoints for them

<br>

## 📢 To Reviewers

- Is it appropriate to set `tokenUrl="/api/v1/login"` in `core.dependencies.auth`?  I don't know if there's a better way...
- I found that better convention for endpoint url is hypen(`-`) than underscore(`_`). I think it would be great to specify our convention for implementing API. (Currently, endpoint url for refresh token is `/refresh_token`)
    
    > ref:
    > 
    > - https://stackoverflow.com/questions/119312/urls-dash-vs-underscore
    > - [https://velog.io/@caesars000/RESTful-API-가이드](https://velog.io/@caesars000/RESTful-API-%EA%B0%80%EC%9D%B4%EB%93%9C)