### PR TITLE
⚙️ setting: Set up local dev docker-compose for postgres and pgadmin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+volumes
+.ruff_cache
+
 # Custom
 .env.*
 **/debug_*

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,28 @@
+services:
+  postgres:
+    image: postgres:16.1-alpine
+    restart: always
+    container_name: postgres
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
+      POSTGRES_DB: "peerloop_local"
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/postgres_data:/var/lib/postgresql/data
+  pgadmin:
+    image: dpage/pgadmin4
+    ports:
+      - 15433:80
+    environment:
+      PGADMIN_DEFAULT_EMAIL: "test@gmail.com"
+      PGADMIN_DEFAULT_PASSWORD: "test"
+    depends_on:
+      - postgres
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/pgadmin_data:/var/lib/pgadmin
+
+volumes:
+  postgres_data:
+  pgadmin_data:


### PR DESCRIPTION
## 💫 Motivation

- Setting up the local development environment through docker-compose gives us the shared dev setting across team members as well as the ease of setting up dependencies such as PostgreSQL server.

<br>

## 📌 Key Changes

- Added `docker-compose.yaml` which `postgres` and `pgadmin` services.

<br>

## 📢 To Reviewers

- Run `docker-compose up` (or with `-d` option to start in a background mode) to start the services.
- I drafted [docker-compose guide](https://bead-sociology-2a1.notion.site/docker-compose-3999be98824744a48a8ada99824b2368?pvs=4) to access postgres server in detail.
- nit) Both `.yaml` and `.yml` extensions are allowed but I preferred to use the explicit `.yaml` extension.
