### PR TITLE
⚙️ setting: Removed pgadmin from docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,17 +11,6 @@ services:
       POSTGRES_DB: "peerloop_local"
     volumes:
       - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/postgres_data:/var/lib/postgresql/data
-  pgadmin:
-    image: dpage/pgadmin4
-    ports:
-      - 15433:80
-    environment:
-      PGADMIN_DEFAULT_EMAIL: "test@gmail.com"
-      PGADMIN_DEFAULT_PASSWORD: "test"
-    depends_on:
-      - postgres
-    volumes:
-      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/pgadmin_data:/var/lib/pgadmin
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## 💫 Motivation

- I don't see a reason to put pgadmin inside the docker compose as it's not a necessary dependency. Although it saves us a bit time downloading pgadmin, I thought dependencies must not have something that's not necessary.
- We can download pgadmin on our own.

<br>

## 📌 Key Changes

- Removed pgadmin from docker compose file.

<br>

## 📢 To Reviewers

- 
